### PR TITLE
Tensorflow 2 compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,15 +3,31 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.6
-  - xarray=0.13.0
-  - netcdf4=1.5.2
-  - dask=2.3.0
-  - xesmf=0.2.0
-  - fire=0.2.1
-  - numpy=1.16.0
-  - matplotlib=3.1.2
-  - seaborn=0.9.0
-  - configargparse=0.15.1
-  - tensorflow=0.14
+  - xarray
+  - netcdf4
+  - dask
+  - xesmf
+  - fire
+  - numpy
+  - matplotlib
+  - seaborn
+  - configargparse
+  - tensorflow>=0.14
   - pip:
-      - cdsapi=0.2.3
+      - cdsapi
+
+# Here are the exact versions I used
+#dependencies:
+#  - python=3.7
+#  - xarray=0.13.0
+#  - netcdf4=1.5.2
+#  - dask=2.3.0
+#  - xesmf=0.2.0
+#  - fire=0.2.1
+#  - numpy=1.16.0
+#  - matplotlib=3.1.2
+#  - seaborn=0.9.0
+#  - configargparse=0.15.1
+#  - tensorflow=0.14.0
+#  - pip:
+#      - cdsapi=0.2.3

--- a/src/train_nn.py
+++ b/src/train_nn.py
@@ -10,9 +10,9 @@ from configargparse import ArgParser
 
 def limit_mem():
     """Limit TF GPU mem usage"""
-    config = tf.ConfigProto()
+    config = tf.compat.v1.ConfigProto()
     config.gpu_options.allow_growth = True
-    tf.Session(config=config)
+    tf.compat.v1.Session(config=config)
 
 
 class DataGenerator(keras.utils.Sequence):
@@ -76,35 +76,80 @@ class DataGenerator(keras.utils.Sequence):
         if self.shuffle == True:
             np.random.shuffle(self.idxs)
 
-class PeriodicConv2D(tf.keras.layers.Conv2D):
-    """Convolution with periodic padding in second spatial dimension (lon)"""
-    def __init__(self, filters, kernel_size, **kwargs):
-        assert type(kernel_size) is int, 'Periodic convolutions only works for square kernels.'
-        self.pad_width = (kernel_size - 1) // 2
-        super().__init__(filters, kernel_size, **kwargs)
-        assert self.padding == 'valid', 'Periodic convolution only works for valid padding.'
-        assert sum(self.strides) == 2, 'Periodic padding only works for stride (1, 1)'
-    
-    def _pad(self, inputs):
-        # Input: [samples, lat, lon, filters]
-        # Periodic padding in lon direction
+# class PeriodicConv2D(tf.keras.layers.Conv2D):
+#     """Convolution with periodic padding in second spatial dimension (lon)"""
+#     def __init__(self, filters, kernel_size, **kwargs):
+#         assert type(kernel_size) is int, 'Periodic convolutions only works for square kernels.'
+#         self.pad_width = (kernel_size - 1) // 2
+#         super().__init__(filters, kernel_size, **kwargs)
+#         assert self.padding == 'valid', 'Periodic convolution only works for valid padding.'
+#         assert sum(self.strides) == 2, 'Periodic padding only works for stride (1, 1)'
+#
+#     def _pad(self, inputs):
+#         # Input: [samples, lat, lon, filters]
+#         # Periodic padding in lon direction
+#         inputs_padded = tf.concat(
+#             [inputs[:, :, -self.pad_width:, :], inputs, inputs[:, :, :self.pad_width, :]], axis=2)
+#         # Zero padding in the lat direction
+#         inputs_padded = tf.pad(inputs_padded, [[0, 0], [self.pad_width, self.pad_width], [0, 0], [0, 0]])
+#         return inputs_padded
+#
+#     def __call__(self, inputs, *args, **kwargs):
+#         # Unfortunate workaround necessary for TF < 1.13
+#         inputs_padded = Lambda(self._pad)(inputs)
+#         return super().__call__(inputs_padded, *args, **kwargs)
+
+class PeriodicPadding2D(tf.keras.layers.Layer):
+    def __init__(self, pad_width, **kwargs):
+        super().__init__(**kwargs)
+        self.pad_width = pad_width
+
+    def call(self, inputs, **kwargs):
+        if self.pad_width == 0:
+            return inputs
         inputs_padded = tf.concat(
             [inputs[:, :, -self.pad_width:, :], inputs, inputs[:, :, :self.pad_width, :]], axis=2)
         # Zero padding in the lat direction
         inputs_padded = tf.pad(inputs_padded, [[0, 0], [self.pad_width, self.pad_width], [0, 0], [0, 0]])
         return inputs_padded
 
-    def __call__(self, inputs, *args, **kwargs):
-        # Unfortunate workaround necessary for TF < 1.13
-        inputs_padded = Lambda(self._pad)(inputs)
-        return super().__call__(inputs_padded, *args, **kwargs)
+    def get_config(self):
+        config = super().get_config()
+        config.update({'pad_width': self.pad_width})
+        return config
 
+
+class PeriodicConv2D(tf.keras.layers.Layer):
+    def __init__(self, filters,
+                 kernel_size,
+                 conv_kwargs={},
+                 **kwargs):
+        super().__init__(**kwargs)
+        self.filters = filters
+        self.kernel_size = kernel_size
+        self.conv_kwargs = conv_kwargs
+        if type(kernel_size) is not int:
+            assert kernel_size[0] == kernel_size[1], 'PeriodicConv2D only works for square kernels'
+            kernel_size = kernel_size[0]
+        pad_width = (kernel_size - 1) // 2
+        self.padding = PeriodicPadding2D(pad_width)
+        self.conv = Conv2D(
+            filters, kernel_size, padding='valid', **conv_kwargs
+        )
+
+    def call(self, inputs):
+        return self.conv(self.padding(inputs))
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({'filters': self.filters, 'kernel_size': self.kernel_size, 'conv_kwargs': self.conv_kwargs})
+        return config
 
 def build_cnn(filters, kernels, input_shape, activation='elu', dr=0):
     """Fully convolutional network"""
     x = input = Input(shape=input_shape)
     for f, k in zip(filters[:-1], kernels[:-1]):
-        x = PeriodicConv2D(f, k, activation=activation)(x)
+        x = PeriodicConv2D(f, k, conv_kwargs={'activation': activation})(x)
         if dr > 0: x = Dropout(dr)(x)
     output = PeriodicConv2D(filters[-1], kernels[-1])(x)
     return keras.models.Model(input, output)
@@ -172,24 +217,6 @@ def create_iterative_predictions(model, dg, max_lead_time=5 * 24):
             lev_idx += nlevs
     return xr.merge(das)
 
-def create_cnn(filters, kernels, dropout=0., activation='elu', periodic=True):
-    assert len(filters) == len(kernels), 'Requires same number of filters and kernel_sizes.'
-    input = Input(shape=(None, None, 1,))
-    x = input
-    for f, k in zip(filters[:-1], kernels[:-1]):
-        if periodic:
-            x = PeriodicConv2D(f, k, padding='valid', activation=activation)(x)
-        else:
-            x = Conv2D(f, k, padding='same', activation=activation)(x)
-        if dropout > 0:
-            x = Dropout(dropout)(x)
-    if periodic:
-        output = PeriodicConv2D(filters[-1], kernels[-1], padding='valid')(x)
-    else:
-        output = Conv2D(filters[-1], kernels[-1], padding='same')(x)
-    model = keras.models.Model(inputs=input, outputs=output)
-    return model
-
 
 def main(datadir, vars, filters, kernels, lr, activation, dr, batch_size, patience, model_save_fn, pred_save_fn,
          train_years, valid_years, test_years, lead_time, gpu, iterative):
@@ -199,8 +226,8 @@ def main(datadir, vars, filters, kernels, lr, activation, dr, batch_size, patien
 
     # Open dataset and create data generators
     # TODO: Flexible input data
-    z = xr.open_mfdataset(f'{datadir}geopotential_500/*.nc', combine='by_coords')
-    t = xr.open_mfdataset(f'{datadir}temperature_850/*.nc', combine='by_coords')
+    z = xr.open_mfdataset(f'{datadir}/geopotential_500/*.nc', combine='by_coords')
+    t = xr.open_mfdataset(f'{datadir}/temperature_850/*.nc', combine='by_coords')
     ds = xr.merge([z, t], compat='override')  # Override level. discarded later anyway.
 
     # TODO: Flexible valid split
@@ -224,7 +251,7 @@ def main(datadir, vars, filters, kernels, lr, activation, dr, batch_size, patien
 
     # Train model
     # TODO: Learning rate schedule
-    model.fit_generator(dg_train, epochs=100, validation_data=dg_valid,
+    model.fit_generator(dg_train, epochs=1, validation_data=dg_valid,
                       callbacks=[tf.keras.callbacks.EarlyStopping(
                           monitor='val_loss',
                           min_delta=0,
@@ -245,7 +272,7 @@ def main(datadir, vars, filters, kernels, lr, activation, dr, batch_size, patien
     # TODO: Make flexible for other states
     z500_valid = load_test_data(f'{datadir}geopotential_500', 'z')
     t850_valid = load_test_data(f'{datadir}temperature_850', 't')
-    valid = xr.merge([z500_valid, t850_valid])
+    valid = xr.merge([z500_valid, t850_valid], compat='override')
     print(evaluate_iterative_forecast(pred, valid).load() if iterative else compute_weighted_rmse(pred, valid).load())
 
 if __name__ == '__main__':

--- a/src/train_nn.py
+++ b/src/train_nn.py
@@ -76,6 +76,7 @@ class DataGenerator(keras.utils.Sequence):
         if self.shuffle == True:
             np.random.shuffle(self.idxs)
 
+# Old implementation for tensorflow=1.x
 # class PeriodicConv2D(tf.keras.layers.Conv2D):
 #     """Convolution with periodic padding in second spatial dimension (lon)"""
 #     def __init__(self, filters, kernel_size, **kwargs):
@@ -124,6 +125,10 @@ class PeriodicConv2D(tf.keras.layers.Layer):
                  kernel_size,
                  conv_kwargs={},
                  **kwargs):
+        """
+        Note that this will not work for tensorflow<1.13 and will throw an error for >=1.14<2.x. 
+        The error does not seem to matter though. The results still look fine.    
+        """
         super().__init__(**kwargs)
         self.filters = filters
         self.kernel_size = kernel_size
@@ -251,7 +256,7 @@ def main(datadir, vars, filters, kernels, lr, activation, dr, batch_size, patien
 
     # Train model
     # TODO: Learning rate schedule
-    model.fit_generator(dg_train, epochs=1, validation_data=dg_valid,
+    model.fit_generator(dg_train, epochs=100, validation_data=dg_valid,
                       callbacks=[tf.keras.callbacks.EarlyStopping(
                           monitor='val_loss',
                           min_delta=0,


### PR DESCRIPTION
The train script is now TF2 compatible but should still run with >=1.14. Unfortunately the implementation of `PeriodicConv2D` throws a warning for <2.x which can be ignored, though. The old implementation is still in `train_nn.py`. 

Also, I removed the exact version numbers again from `environment.yml` because this seems to have caused some problems (see #12). But I added the exact version numbers I used as a comment in the environment file.